### PR TITLE
Restore Windows build-ability

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "syn68k"]
 	path = syn68k
-	url = https://github.com/autc04/syn68k
+	url = https://github.com/davidludwig/syn68k
 [submodule "PowerCore"]
 	path = PowerCore
-	url = https://github.com/autc04/PowerCore.git
+	url = https://github.com/davidludwig/PowerCore.git
 [submodule "cxmon"]
 	path = cxmon
 	url = https://github.com/autc04/cxmon.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
+
+# Use packaged CMake modules for use with find_package(...), if and as needed
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
 project(Executor)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,27 @@ set(CMAKE_CXX_STANDARD 17)
 
 cmake_policy(SET CMP0020 NEW) # Automatically link Qt executables to qtmain target on Windows.
 
+if(WIN32)
+    add_compile_options(
+        # Limit to compiling as a 32-bit-app, for now, as some things fail to compile otherwise
+        -m32
+
+        # Prevent currently-non-compiling assembly functions from being included 
+        -DNO_FAST_CC_FUNCS
+
+        # Don't warn if older C-runtime functions get used
+        -D_CRT_SECURE_NO_WARNINGS
+
+        # FIXME: disable common warnings, for now
+        -Wno-unused-variable
+        -Wno-deprecated-declarations
+        -Wno-unused-function
+        -Wno-unused-lambda-capture
+    )
+
+    include_directories(BEFORE ${CMAKE_CURRENT_LIST_DIR}/windows)
+endif()
+
 if( NOT EXISTS "${CMAKE_SOURCE_DIR}/syn68k/.git" )
     message( FATAL_ERROR
         "The git submodule 'syn68k' is not available. Please run\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,4 +66,7 @@ add_subdirectory(syn68k)
 add_subdirectory(PowerCore)
 add_subdirectory(cxmon)
 add_subdirectory(src)
-add_subdirectory(tests)
+if(NOT WIN32)
+    # Test code does not, yet, compile on Windows
+    add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Executor 2000 feature highlights:
   - Lots of code cleanup, according to my own definition of "clean"
   - included debugger based on cxmon from Basilisk
   - started a test suite
-  - Removed old, no longer functioning, DOS, NeXT and Windows ports.
+  - Removed old, no longer functioning, DOS, NeXT and Windows ports. (Windows
+    still works, though, via Qt and SDL ports.)
   - I probably broke lots of other things that used to work.
 
 You can reach the maintainer of this fork at wolfgang.thaller@gmx.net or via
@@ -76,12 +77,14 @@ Ernst Oud - Documentation, Testing
 After Executor's open-sourcing, C.W. Betts (https://github.com/MaddTheSane)
 picked it up and ported the whole thing from plain C to C++.
 And after that, yours truly, Wolfgang Thaller (https://github.com/autc04) took
-posession of it...
+posession of it.  Other contributors include:
+
+  - David Ludwig (https://github.com/DavidLudwig) - Windows build fixes
 
 Building and Running
 --------------------
 
-Needs a modern C++ compiler, CMake, and Qt 5.
+Needs a modern C++ compiler, CMake, and Qt 5, plus 'perl' and 'bison' commands.
 SDL2, SDL1.2 or X11 libraries are required to build some of the alternate front-ends.
 
 ```
@@ -90,7 +93,7 @@ git submodule update
 mkdir build
 cd build
 cmake ..
-make
+cmake --build .
 ```
 
 When `./build/src/executor` is first invoked, it will automatically install its
@@ -107,3 +110,62 @@ export QT_QPA_PLATFORM=xcb
 Executor 2000 should be able to use native Mac files on macOS, AppleDouble 
 file pairs (`foo` and `%foo`) as used by older executor verions, as well as
 files written by Basilisk or SheepShaver (`foo`, `.rsrc/foo` and `.finf/foo`).
+
+
+### Microsoft Windows
+
+Executor 2000 can be built for Microsoft Windows, albeit only as a 32-bit
+Windows Desktop (i.e. Win32) application.  The build procedure is nearly the
+same, however, some additional dependencies need to be installed, and then,
+some extra options need to be passed into CMake.
+
+The following procedure has been used to prepare a Windows 10 machine to build
+Executor 2000 as a Windows app.  Some of Microsoft's
+[free, time-use-limited Windows VM images](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines)
+have, in the past, been sufficient to build Executor 2000.  If you try this,
+please note that these VMs did have some, but not all of the above dependencies
+already installed.
+
+Command line steps be performed once Visual Studio 2017 is installed, by
+running the Start Menu searchable program, ```Developer Command Prompt for VS 2017```
+
+1. install [Git](https://git-scm.com/download)
+2. install [CMake](https://cmake.org/download/)
+3. install [LLVM](http://releases.llvm.org/download.html). (8.0.0, pre-built
+   binaries have been used, for example.)
+4. install [Visual Studio 2017](https://visualstudio.microsoft.com/), plus it's
+   [Desktop Development with C++](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=vs-2017)
+   option 
+5. install the VS-2017 add-on,
+   [LLVM Compiler Toolchain](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain)
+6. install perl and bison, via MinGW-get's packages for
+   ```msys-bison-bin``` and ```msys-perl-bin``` - [MinGW Getting Started](http://www.mingw.org/wiki/getting_started)
+7. add perl and bison to path.  If MinGW is installed to C:\MinGW, the
+   directory to add to PATH should be, ```C:\MinGW\msys\1.0\bin```.
+8. install [vcpkg](https://github.com/Microsoft/vcpkg).  Installation to
+   ```C:\vcpkg``` is recommended (but not strictly required, perhaps).
+9. use vcpkg to build and install Qt5, SDL2, and Boost.  This may take
+   multiple hours to perform (due primarily to Qt).
+   1. ```cd C:\vcpkg```
+   2. ```vcpkg install sdl2 boost-filesystem boost-system qt5-base```
+
+With the above steps performed, building was done using the normal procedure,
+as listed above), but with the cmake-configuration step (aka. ```cmake ..```)
+being issued as such:
+
+```cmake -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake -T"llvm" ..```
+
+The important and new parts here are:
+
+  - ```-DCMAKE_TOOLCHAIN_FILE=...```: lets the build system know about the
+    vcpkg-installed dependencies.
+  - ```-T"llvm"```: lets the build system know to use Clang to compile
+    C/C++ code (rather than Microsoft's Visual C++ engine, for example).
+
+By default, the build step (of ```cmake --build .```) will generate a Debug
+build.  To make a Release build, run the build step as such:
+
+```cmake --build . --config Release```
+
+The resulting ```executor.exe``` will be in the ```Release``` sub-folder
+(or ```Debug```, for Debug builds).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ re-implement the classic Mac OS APIs, just as WINE does for Windows.
 Executor 2000 feature highlights:
 
   - Builds and runs on modern 64-bit Linux and macOS (Windows support is planned).
-  - Rootless - emulated Windows are part of your desktop.
+  - Rootless - emulated windows are part of your desktop.
   - PowerPC support (well, not many Apps will run, but it's there)
   - Support for native Mac resource forks (Mac version)
   - Exchange files with Basilisk & SheepShaver

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -1,0 +1,173 @@
+
+# This module defines
+# SDL2_LIBRARY, the name of the library to link against
+# SDL2_FOUND, if false, do not try to link to SDL2
+# SDL2_INCLUDE_DIR, where to find SDL.h
+#
+# This module responds to the the flag:
+# SDL2_BUILDING_LIBRARY
+# If this is defined, then no SDL2main will be linked in because
+# only applications need main().
+# Otherwise, it is assumed you are building an application and this
+# module will attempt to locate and set the the proper link flags
+# as part of the returned SDL2_LIBRARY variable.
+#
+# Don't forget to include SDLmain.h and SDLmain.m your project for the
+# OS X framework based version. (Other versions link to -lSDL2main which
+# this module will try to find on your behalf.) Also for OS X, this
+# module will automatically add the -framework Cocoa on your behalf.
+#
+#
+# Additional Note: If you see an empty SDL2_LIBRARY_TEMP in your configuration
+# and no SDL2_LIBRARY, it means CMake did not find your SDL2 library
+# (SDL2.dll, libsdl2.so, SDL2.framework, etc).
+# Set SDL2_LIBRARY_TEMP to point to your SDL2 library, and configure again.
+# Similarly, if you see an empty SDL2MAIN_LIBRARY, you should set this value
+# as appropriate. These values are used to generate the final SDL2_LIBRARY
+# variable, but when these values are unset, SDL2_LIBRARY does not get created.
+#
+#
+# $SDL2DIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDL2DIR
+# used in building SDL2.
+# l.e.galup  9-20-02
+#
+# Modified by Eric Wing.
+# Added code to assist with automated building by using environmental variables
+# and providing a more controlled/consistent search behavior.
+# Added new modifications to recognize OS X frameworks and
+# additional Unix paths (FreeBSD, etc).
+# Also corrected the header search path to follow "proper" SDL guidelines.
+# Added a search for SDL2main which is needed by some platforms.
+# Added a search for threads which is needed by some platforms.
+# Added needed compile switches for MinGW.
+#
+# On OSX, this will prefer the Framework version (if found) over others.
+# People will have to manually change the cache values of
+# SDL2_LIBRARY to override this selection or set the CMake environment
+# CMAKE_INCLUDE_PATH to modify the search paths.
+#
+# Note that the header path has changed from SDL2/SDL.h to just SDL.h
+# This needed to change because "proper" SDL convention
+# is #include "SDL.h", not <SDL2/SDL.h>. This is done for portability
+# reasons because not all systems place things in SDL2/ (see FreeBSD).
+
+#=============================================================================
+# Copyright 2003-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+# message("<FindSDL2.cmake>")
+
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+	${SDL2_PATH}
+)
+
+FIND_PATH(SDL2_INCLUDE_DIR SDL.h
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES include/SDL2 include
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8) 
+	set(PATH_SUFFIXES lib64 lib/x64 lib)
+else() 
+	set(PATH_SUFFIXES lib/x86 lib)
+endif() 
+
+FIND_LIBRARY(SDL2_LIBRARY_TEMP
+	NAMES SDL2
+	HINTS
+	$ENV{SDL2DIR}
+	PATH_SUFFIXES ${PATH_SUFFIXES}
+	PATHS ${SDL2_SEARCH_PATHS}
+)
+
+IF(NOT SDL2_BUILDING_LIBRARY)
+	IF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+		# Non-OS X framework versions expect you to also dynamically link to
+		# SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+		# seem to provide SDL2main for compatibility even though they don't
+		# necessarily need it.
+		FIND_LIBRARY(SDL2MAIN_LIBRARY
+			NAMES SDL2main
+			HINTS
+			$ENV{SDL2DIR}
+			PATH_SUFFIXES ${PATH_SUFFIXES}
+			PATHS ${SDL2_SEARCH_PATHS}
+		)
+	ENDIF(NOT ${SDL2_INCLUDE_DIR} MATCHES ".framework")
+ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+IF(NOT APPLE)
+	FIND_PACKAGE(Threads)
+ENDIF(NOT APPLE)
+
+# MinGW needs an additional link flag, -mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -mwindows
+IF(MINGW)
+	SET(MINGW32_LIBRARY mingw32 "-mwindows" CACHE STRING "mwindows for MinGW")
+ENDIF(MINGW)
+
+IF(SDL2_LIBRARY_TEMP)
+	# For SDL2main
+	IF(NOT SDL2_BUILDING_LIBRARY)
+		IF(SDL2MAIN_LIBRARY)
+			SET(SDL2_LIBRARY_TEMP ${SDL2MAIN_LIBRARY} ${SDL2_LIBRARY_TEMP})
+		ENDIF(SDL2MAIN_LIBRARY)
+	ENDIF(NOT SDL2_BUILDING_LIBRARY)
+
+	# For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+	# CMake doesn't display the -framework Cocoa string in the UI even
+	# though it actually is there if I modify a pre-used variable.
+	# I think it has something to do with the CACHE STRING.
+	# So I use a temporary variable until the end so I can set the
+	# "real" variable in one-shot.
+	IF(APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} "-framework Cocoa")
+	ENDIF(APPLE)
+
+	# For threads, as mentioned Apple doesn't need this.
+	# In fact, there seems to be a problem if I used the Threads package
+	# and try using this line, so I'm just skipping it entirely for OS X.
+	IF(NOT APPLE)
+		SET(SDL2_LIBRARY_TEMP ${SDL2_LIBRARY_TEMP} ${CMAKE_THREAD_LIBS_INIT})
+	ENDIF(NOT APPLE)
+
+	# For MinGW library
+	IF(MINGW)
+		SET(SDL2_LIBRARY_TEMP ${MINGW32_LIBRARY} ${SDL2_LIBRARY_TEMP})
+	ENDIF(MINGW)
+
+	# Set the final string here so the GUI reflects the final state.
+	SET(SDL2_LIBRARY ${SDL2_LIBRARY_TEMP} CACHE STRING "Where the SDL2 Library can be found")
+	# Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+	SET(SDL2_LIBRARY_TEMP "${SDL2_LIBRARY_TEMP}" CACHE INTERNAL "")
+ENDIF(SDL2_LIBRARY_TEMP)
+
+# message("</FindSDL2.cmake>")
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2 REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,14 @@ cmake_minimum_required(VERSION 3.9)
 find_program(PERL_COMMAND perl)
 
 find_package(Boost COMPONENTS filesystem system)
+if(NOT PERL_COMMAND)
+    message(FATAL_ERROR "Cannot find command: 'perl' (needed for building!)")
+endif()
 
 find_program(BISON_COMMAND bison)
+if(NOT BISON_COMMAND)
+    message(FATAL_ERROR "Cannot find command: 'bison' (needed for building!)")
+endif()
 find_package(Threads REQUIRED)
 
 include_directories(include/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
 find_program(PERL_COMMAND perl)
-
-find_package(Boost COMPONENTS filesystem system)
 if(NOT PERL_COMMAND)
     message(FATAL_ERROR "Cannot find command: 'perl' (needed for building!)")
 endif()
@@ -11,6 +9,9 @@ find_program(BISON_COMMAND bison)
 if(NOT BISON_COMMAND)
     message(FATAL_ERROR "Cannot find command: 'bison' (needed for building!)")
 endif()
+
+find_package(Boost REQUIRED COMPONENTS filesystem system)
+
 find_package(Threads REQUIRED)
 
 include_directories(include/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -565,12 +565,7 @@ endif()
 
 target_link_libraries(romlib Threads::Threads syn68k PowerCore mon)
 
-#target_link_libraries(romlib Boost::filesystem)  # mxe doesn't like this
-if(WIN32) # MXE hack
-    target_link_libraries(romlib ${Boost_LIBRARIES})
-else()
-    target_link_libraries(romlib Boost::filesystem)  # mxe doesn't like this
-endif()
+target_link_libraries(romlib Boost::filesystem)  # mxe doesn't like this
 target_link_libraries(romlib resources)
 
 add_executable(executor main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -529,6 +529,13 @@ set(include_sources
 
 include(trap_instances/trap_instances.cmake)
 
+if(WIN32)
+    set(host_platform_sources ../windows/dirent.c ../windows/gettimeofday.cpp)
+else()
+    set(host_platform_sources)
+endif()
+source_group(HostPlatform FILES ${host_platform_sources})
+
 set(sources ${base_sources} ${mman_sources} ${vdriver_sources}
     ${ctl_sources} ${dial_sources} 
     ${list_sources} ${menu_sources}
@@ -537,7 +544,7 @@ set(sources ${base_sources} ${mman_sources} ${vdriver_sources}
     ${sound_sources} ${num_sources} ${misc_sources}
     ${file_sources} ${hfs_sources} ${time_sources} ${osevent_sources}
     ${error_sources} ${commandline_sources} ${prefs_sources}
-    ${trap_instance_sources}
+    ${trap_instance_sources} ${host_platform_sources}
     ${include_sources})
 
 add_library(romlib ${sources}

--- a/src/base/logging.cpp
+++ b/src/base/logging.cpp
@@ -1,5 +1,6 @@
 #include <base/logging.h>
 #include <iomanip>
+#include <cctype>
 
 using namespace Executor;
 
@@ -45,7 +46,7 @@ bool logging::canConvertBack(const void* p)
 {
     if(!p || p == (const void*) -1)
         return true;
-#if SIZEOF_VOID_P == 4
+#if SIZEOF_CHAR_P == 4
     bool valid = true;
 #else
     bool valid = false;
@@ -65,7 +66,7 @@ bool logging::validAddress(const void* p)
         return false;
     if( (uintptr_t)p & 1 )
         return false;
-#if SIZEOF_VOID_P == 4
+#if SIZEOF_CHAR_P == 4
     bool valid = true;
 #else
     bool valid = false;

--- a/src/config/front-ends/sdl2/CMakeLists.txt
+++ b/src/config/front-ends/sdl2/CMakeLists.txt
@@ -7,13 +7,13 @@ if(SDL2_FOUND)
         keycode_map.cpp
     )
 
-        # workaround for SDL2_LIBRARIES containing trailing whitespace that is illegal in CMake 3.10
-    if(SDL2_LIBRARIES)
-        string(STRIP ${SDL2_LIBRARIES} SDL2_LIBRARIES)
+    # workaround for SDL2_LIBRARY containing trailing whitespace that is illegal in CMake 3.10
+    if(SDL2_LIBRARY)
+        string(STRIP "${SDL2_LIBRARY}" SDL2_LIBRARY)
     endif()
 
-    target_link_libraries(front-end-sdl2 syn68k ${SDL2_LIBRARIES})
+    target_link_libraries(front-end-sdl2 syn68k ${SDL2_LIBRARY})
     target_include_directories(front-end-sdl2
         PUBLIC .
-        PRIVATE ${SDL2_INCLUDE_DIRS} ${SDL2_INCLUDE_DIRS}/SDL2)
+        PRIVATE ${SDL2_INCLUDE_DIR} ${SDL2_INCLUDE_DIR}/SDL2)
 endif()

--- a/src/config/os/win32/win32.cpp
+++ b/src/config/os/win32/win32.cpp
@@ -1,4 +1,6 @@
+#define _WINSOCKAPI_ // Make sure windows.h doesn't #include <winsock.h>, which can redefine 'struct timeval'
 #include <windows.h>
+
 #include <base/common.h>
 #include <rsys/lockunlock.h>
 #include <rsys/os.h>

--- a/src/config/os/win32/win32.h
+++ b/src/config/os/win32/win32.h
@@ -7,17 +7,24 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/time.h>
+#include <dirent.h>
+#include <io.h>
+
+#ifdef _MSC_VER
+#define strcasecmp _stricmp
+#endif
 
 #ifndef _MSC_VER
 #include <unistd.h>
-#include <sys/time.h>
-#include <dirent.h>
 //#include <sys/vfs.h>
 #include <sys/param.h>
 //#include <sys/errno.h>
 #endif
 
 #define CONFIG_OFFSET_P 1 /* Use offset memory, at least for the first port */
+
+typedef int ssize_t;
 
 extern int ROMlib_launch_native_app(int n_filenames, char **filenames);
 

--- a/src/config/os/win32/win_serial.cpp
+++ b/src/config/os/win32/win_serial.cpp
@@ -3,6 +3,7 @@
  * All rights reserved.
  */
 
+#define _WINSOCKAPI_ // Make sure windows.h doesn't #include <winsock.h>, which can redefine 'struct timeval'
 #include <windows.h>
 
 #include <base/common.h>

--- a/src/config/os/win32/win_stat.cpp
+++ b/src/config/os/win32/win_stat.cpp
@@ -8,6 +8,7 @@
 
 #include <base/common.h>
 
+#define _WINSOCKAPI_ // Make sure windows.h doesn't #include <winsock.h>, which can redefine 'struct timeval'
 #include <windows.h>
 
 #include <ctype.h>

--- a/src/config/os/win32/winfs.cpp
+++ b/src/config/os/win32/winfs.cpp
@@ -5,7 +5,9 @@
 
 #include <base/common.h>
 
+#define _WINSOCKAPI_    // Make sure windows.h doesn't #include <winsock.h>, which can redefine 'struct timeval'
 #include <windows.h>
+
 #include <stdio.h>
 #include <errno.h>
 

--- a/src/config/os/win32/winfs.cpp
+++ b/src/config/os/win32/winfs.cpp
@@ -10,9 +10,16 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <direct.h>
 
 #include "winfs.h"
 #include <rsys/lockunlock.h>
+
+#if _MSC_VER
+#ifndef MAXPATHLEN
+#define MAXPATHLEN _MAX_PATH
+#endif
+#endif
 
 using namespace Executor;
 

--- a/src/file/fileMisc.cpp
+++ b/src/file/fileMisc.cpp
@@ -29,6 +29,10 @@
 //#include "dosdisk.h"
 #endif
 
+#ifndef S_ISDIR
+#define S_ISDIR(m) ((m) & S_IFDIR)
+#endif
+
 #include <ctype.h>
 #include <algorithm>
 

--- a/src/file/fileMisc.cpp
+++ b/src/file/fileMisc.cpp
@@ -535,7 +535,7 @@ void Executor::InitPaths()
     fs::path systemFolder = ROMlib_SystemFolder;
 
     auto copyfile = [&](fs::path dest, auto from) {
-        fs::ofstream out(dest);
+        fs::ofstream out(dest, std::ios::binary);
         std::ostreambuf_iterator<char> begin_dest(out);
         std::copy(from.begin(), from.end(), begin_dest);
     };

--- a/src/file/localvolume/localvolume.cpp
+++ b/src/file/localvolume/localvolume.cpp
@@ -524,7 +524,7 @@ LocalVolume::NonexistentFile LocalVolume::resolveForCreate(mac_string_view name,
         parent = resolveDir(vRefNum, dirID);
     else
     {
-        parent = std::dynamic_pointer_cast<DirectoryItem>(resolve(mac_string_view(name.begin(), colon), vRefNum, dirID));
+        parent = std::dynamic_pointer_cast<DirectoryItem>(resolve(mac_string_view(name.data(), colon), vRefNum, dirID));
         if(!parent)
             throw OSErrorException(dirNFErr);
         name = mac_string_view(name.begin() + colon+1, name.end());

--- a/src/file/localvolume/plain.cpp
+++ b/src/file/localvolume/plain.cpp
@@ -33,7 +33,9 @@ PlainDataFork::~PlainDataFork()
 
 size_t PlainDataFork::getEOF()
 {
-    return lseek(fd, 0,SEEK_END);
+    if(fd <= 0)
+        return -1;
+    return lseek(fd, 0, SEEK_END);
 }
 void PlainDataFork::setEOF(size_t sz)
 {

--- a/src/file/localvolume/plain.cpp
+++ b/src/file/localvolume/plain.cpp
@@ -1,6 +1,8 @@
 #include "plain.h"
 #include "host-os-config.h"
-#include <unistd.h>
+#if !defined(WIN32)
+    #include <unistd.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -35,7 +37,11 @@ size_t PlainDataFork::getEOF()
 }
 void PlainDataFork::setEOF(size_t sz)
 {
+#if defined(WIN32)
+    chsize(fd, sz);
+#else
     ftruncate(fd, sz);
+#endif
 }
 
 size_t PlainDataFork::read(size_t offset, void *p, size_t n)

--- a/src/launch.cpp
+++ b/src/launch.cpp
@@ -223,10 +223,17 @@ cfm_launch(Handle cfrg0, OSType desired_arch, FSSpecPtr fsp)
 
             cpu.syscall = &builtinlibs::handleSC;
 
+#if SIZEOF_CHAR_P == 4
+            cpu.memoryBases[0] = (void*)ROMlib_offset;
+            cpu.memoryBases[1] = nullptr;
+            cpu.memoryBases[2] = nullptr;
+            cpu.memoryBases[3] = nullptr;
+#elif SIZEOF_CHAR_P >= 8
             cpu.memoryBases[0] = (void*)ROMlib_offsets[0];
             cpu.memoryBases[1] = (void*)ROMlib_offsets[1];
             cpu.memoryBases[2] = (void*)ROMlib_offsets[2];
             cpu.memoryBases[3] = (void*)ROMlib_offsets[3];
+#endif
 
             base::Debugger::instance->initProcess(new_pc);
             executePPC(new_pc);

--- a/src/prefs/prefs.cpp
+++ b/src/prefs/prefs.cpp
@@ -1,3 +1,6 @@
+
+#include <dirent.h>
+
 #include <prefs/prefs.h>
 #include <prefs/options.h>
 #include <prefs/parse.h>

--- a/src/print/prPrinting.cpp
+++ b/src/print/prPrinting.cpp
@@ -589,7 +589,7 @@ void Executor::C_PrCloseDoc(TPPrPort port)
 
     if(need_pclose)
     {
-#if !defined(CYGWIN32)
+#if !defined(CYGWIN32) && !defined(_MSC_VER)
         pclose(ROMlib_printfile);
 #else
         ; /* CYGWIN32 has no pclose */

--- a/src/qColorPicker.cpp
+++ b/src/qColorPicker.cpp
@@ -23,6 +23,7 @@
 #include <prefs/options.h>
 
 #include <ctype.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <algorithm>
 

--- a/src/sane/float5.cpp
+++ b/src/sane/float5.cpp
@@ -4,6 +4,7 @@
 
 #include <base/common.h>
 
+#define _USE_MATH_DEFINES
 #include <math.h>
 
 #include <SANE.h>

--- a/src/time/syncint.cpp
+++ b/src/time/syncint.cpp
@@ -76,6 +76,11 @@ void Executor::syncint_wait_interrupt()
 {
     std::unique_lock<std::mutex> lock(mutex);
     wake_cond.wait_for(lock, 1s, []() { return INTERRUPT_PENDING(); });
+
+    // unlock here, in case the subsequent call to syncint_check_interrupt()
+    // triggers a call to syncint_post(), which will need to lock 'mutex'.
+    lock.unlock();
+
     syncint_check_interrupt();
 }
 

--- a/src/wind/windSize.cpp
+++ b/src/wind/windSize.cpp
@@ -16,6 +16,8 @@
 #include <quickdraw/cquick.h>
 #include <wind/wind.h>
 
+#include <algorithm>
+
 using namespace Executor;
 
 /*

--- a/windows/dirent.c
+++ b/windows/dirent.c
@@ -1,0 +1,148 @@
+/*
+
+    Implementation of POSIX directory browsing functions and types for Win32.
+
+    Author:  Kevlin Henney (kevlin@acm.org, kevlin@curbralan.com)
+    History: Created March 1997. Updated June 2003 and July 2012.
+    Rights:  See end of file.
+
+*/
+
+#include <dirent.h>
+#include <errno.h>
+#include <io.h> /* _findfirst and _findnext set errno iff they return -1 */
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef ptrdiff_t handle_type; /* C99's intptr_t not sufficiently portable */
+
+struct DIR
+{
+    handle_type         handle; /* -1 for failed rewind */
+    struct _finddata_t  info;
+    struct dirent       result; /* d_name null iff first time */
+    char                *name;  /* null-terminated char string */
+};
+
+DIR *opendir(const char *name)
+{
+    DIR *dir = 0;
+
+    if(name && name[0])
+    {
+        size_t base_length = strlen(name);
+        const char *all = /* search pattern must end with suitable wildcard */
+            strchr("/\\", name[base_length - 1]) ? "*" : "/*";
+
+        if((dir = (DIR *) malloc(sizeof *dir)) != 0 &&
+           (dir->name = (char *) malloc(base_length + strlen(all) + 1)) != 0)
+        {
+            strcat(strcpy(dir->name, name), all);
+
+            if((dir->handle =
+                (handle_type) _findfirst(dir->name, &dir->info)) != -1)
+            {
+                dir->result.d_name = 0;
+            }
+            else /* rollback */
+            {
+                free(dir->name);
+                free(dir);
+                dir = 0;
+            }
+        }
+        else /* rollback */
+        {
+            free(dir);
+            dir   = 0;
+            errno = ENOMEM;
+        }
+    }
+    else
+    {
+        errno = EINVAL;
+    }
+
+    return dir;
+}
+
+int closedir(DIR *dir)
+{
+    int result = -1;
+
+    if(dir)
+    {
+        if(dir->handle != -1)
+        {
+            result = _findclose(dir->handle);
+        }
+
+        free(dir->name);
+        free(dir);
+    }
+
+    if(result == -1) /* map all errors to EBADF */
+    {
+        errno = EBADF;
+    }
+
+    return result;
+}
+
+struct dirent *readdir(DIR *dir)
+{
+    struct dirent *result = 0;
+
+    if(dir && dir->handle != -1)
+    {
+        if(!dir->result.d_name || _findnext(dir->handle, &dir->info) != -1)
+        {
+            result         = &dir->result;
+            result->d_name = dir->info.name;
+        }
+    }
+    else
+    {
+        errno = EBADF;
+    }
+
+    return result;
+}
+
+void rewinddir(DIR *dir)
+{
+    if(dir && dir->handle != -1)
+    {
+        _findclose(dir->handle);
+        dir->handle = (handle_type) _findfirst(dir->name, &dir->info);
+        dir->result.d_name = 0;
+    }
+    else
+    {
+        errno = EBADF;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/*
+
+    Copyright Kevlin Henney, 1997, 2003, 2012. All rights reserved.
+
+    Permission to use, copy, modify, and distribute this software and its
+    documentation for any purpose is hereby granted without fee, provided
+    that this copyright and permissions notice appear in all copies and
+    derivatives.
+    
+    This software is supplied "as is" without express or implied warranty.
+
+    But that said, if there are any problems please get in touch.
+
+*/

--- a/windows/dirent.h
+++ b/windows/dirent.h
@@ -1,0 +1,50 @@
+#ifndef DIRENT_INCLUDED
+#define DIRENT_INCLUDED
+
+/*
+
+    Declaration of POSIX directory browsing functions and types for Win32.
+
+    Author:  Kevlin Henney (kevlin@acm.org, kevlin@curbralan.com)
+    History: Created March 1997. Updated June 2003.
+    Rights:  See end of file.
+    
+*/
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct DIR DIR;
+
+struct dirent
+{
+    char *d_name;
+};
+
+DIR           *opendir(const char *);
+int           closedir(DIR *);
+struct dirent *readdir(DIR *);
+void          rewinddir(DIR *);
+
+/*
+
+    Copyright Kevlin Henney, 1997, 2003. All rights reserved.
+
+    Permission to use, copy, modify, and distribute this software and its
+    documentation for any purpose is hereby granted without fee, provided
+    that this copyright and permissions notice appear in all copies and
+    derivatives.
+    
+    This software is supplied "as is" without express or implied warranty.
+
+    But that said, if there are any problems please get in touch.
+
+*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/windows/gettimeofday.cpp
+++ b/windows/gettimeofday.cpp
@@ -1,0 +1,72 @@
+
+#include <sys/time.h>
+//#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <chrono>
+
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+    auto now = std::chrono::system_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());;
+    if (tv) {
+        tv->tv_sec = ms.count() / 1000;
+        tv->tv_usec = (ms.count() % 1000) * 1000;
+    }
+    return 0;
+}
+
+#if 0
+#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
+  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
+#else
+  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
+#endif
+
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+  FILETIME ft;
+  unsigned __int64 tmpres = 0;
+  static int tzflag = 0;
+
+  if (NULL != tv)
+  {
+    GetSystemTimeAsFileTime(&ft);
+
+    tmpres |= ft.dwHighDateTime;
+    tmpres <<= 32;
+    tmpres |= ft.dwLowDateTime;
+
+    tmpres /= 10;  /*convert into microseconds*/
+    /*converting file time to unix epoch*/
+    tmpres -= DELTA_EPOCH_IN_MICROSECS; 
+    tv->tv_sec = (long)(tmpres / 1000000UL);
+    tv->tv_usec = (long)(tmpres % 1000000UL);
+  }
+
+  if (NULL != tz)
+  {
+    if (!tzflag)
+    {
+      _tzset();
+      tzflag++;
+    }
+    tz->tz_minuteswest = _timezone / 60;
+    tz->tz_dsttime = _daylight;
+  }
+
+  return 0;
+}
+
+#define TEST
+#ifdef TEST
+int main()
+{
+  struct timeval now; 
+  struct timezone tzone;
+
+  gettimeofday(&now, NULL);
+  gettimeofday(&now, &tzone);
+}
+#endif
+#endif

--- a/windows/sys/time.h
+++ b/windows/sys/time.h
@@ -1,0 +1,23 @@
+#ifndef _sys_time_h
+#define _sys_time_h
+
+#include <time.h>
+
+struct timezone
+{
+    int tz_minuteswest; /* minutes W of Greenwich */
+    int tz_dsttime;     /* type of dst correction */
+};
+
+struct timeval
+{
+    long tv_sec;  /* seconds */
+    long tv_usec; /* microseconds */
+};
+
+#ifdef __cplusplus
+extern "C"
+#endif
+int gettimeofday(struct timeval *tv, struct timezone *tz);
+
+#endif // _sys_time_h


### PR DESCRIPTION
This set of changes allows Executor 2000 to be built under Microsoft Windows.  It builds using a combination of Visual Studio 2017 and LLVM/Clang.  Instructions for building have been added to the README.md file.  Both Qt and SDL2 backends have been tested and are working.