### PR TITLE
#include <memory> added to build with debian sid

### DIFF
--- a/src/mpw/mpw.cpp
+++ b/src/mpw/mpw.cpp
@@ -16,6 +16,8 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#include <memory>
+
 using namespace Executor;
 using namespace Executor::mpw;
 


### PR DESCRIPTION
Got: "error: ‘unique_ptr’ is not a member of ‘std’" from src/mpw/mpw.cpp
Added a standard solution with "#include <memory>" and it works.