### PR TITLE
Include functional in macosx.mm

### DIFF
--- a/src/config/os/macosx/macosx.mm
+++ b/src/config/os/macosx/macosx.mm
@@ -1,6 +1,7 @@
 #define _block_h_
 #include <Cocoa/Cocoa.h>
 #include <algorithm>
+#include <functional>
 
 static bool inited = false;
 static bool dock = false;


### PR DESCRIPTION
This prevents the following error when building
config/os/macosx/macosx.mm:

    error: no template named 'function' in namespace 'std'