### PR TITLE
Fix legacy font names

### DIFF
--- a/src/aboutbox.cpp
+++ b/src/aboutbox.cpp
@@ -498,7 +498,7 @@ event_loop()
                 ForeColor(blackColor);
                 BackColor(whiteColor);
                 EraseRect(&about_box->portRect);
-                TextFont(helvetica);
+                TextFont(kFontIDHelvetica);
                 TextSize(24);
                 MoveTo(TE_LEFT, 30);
                 DrawText_c_string(ROMlib_executor_full_name);

--- a/src/osutil.cpp
+++ b/src/osutil.cpp
@@ -635,7 +635,7 @@ static void setdefaults()
     LM(SPATalkB) = LM(SPATalkA) = LM(SPConfig) = 0;
     LM(SPPortB) = LM(SPPortA) = baud9600 | stop10 | data8 | noParity;
     LM(SPPrint) = 0;
-    LM(SPFont) = geneva - 1;
+    LM(SPFont) = kFontIDGeneva - 1;
     LM(SPKbd) = 0x63;
     LM(SPVolCtl) = 3;
     LM(SPClikCaret) = 0x88;

--- a/src/print/PSprint.cpp
+++ b/src/print/PSprint.cpp
@@ -1991,7 +1991,7 @@ void Executor::NeXTPrText(LONGINT n, Ptr textbufp, Point num, Point den,
     int n_leading_spaces;
     int run_start, run_stop;
 
-    if(thePortp->txFont != symbol)
+    if(thePortp->txFont != kFontIDSymbol)
     {
         find_run_of_symbol_chars(n, textbufp, &run_start, &run_stop);
         if(run_start >= 0)
@@ -2001,7 +2001,7 @@ void Executor::NeXTPrText(LONGINT n, Ptr textbufp, Point num, Point den,
             if(run_start > 0)
                 NeXTPrText(run_start, textbufp, num, den, thePortp);
             save_font = thePortp->txFont;
-            thePortp->txFont = symbol;
+            thePortp->txFont = kFontIDSymbol;
             NeXTPrText(run_stop - run_start, textbufp + run_start, num, den,
                        thePortp);
             thePortp->txFont = save_font;
@@ -2051,7 +2051,7 @@ void Executor::NeXTPrText(LONGINT n, Ptr textbufp, Point num, Point den,
             translated[n] = 0;
             if(n)
             {
-                if(thePortp->txFont == symbol)
+                if(thePortp->txFont == kFontIDSymbol)
                 {
                     int i;
 
@@ -2063,7 +2063,7 @@ void Executor::NeXTPrText(LONGINT n, Ptr textbufp, Point num, Point den,
 #if 0
 		PSxshow(translated, fwidths, n);
 #else
-                if(ROMlib_fontsubstitution && (thePortp->txFont == geneva))
+                if(ROMlib_fontsubstitution && (thePortp->txFont == kFontIDGeneva))
                     doshow(translated, n);
                 else if((i = numspacesin(translated)))
                     dowidthshow(translated, n, i, total);
@@ -2073,7 +2073,7 @@ void Executor::NeXTPrText(LONGINT n, Ptr textbufp, Point num, Point den,
                 if(thePortp->txFace & underline)
                     dopsunderline(thePortp, total,
                                   ROMlib_fontsubstitution
-                                      && (thePortp->txFont == geneva),
+                                      && (thePortp->txFont == kFontIDGeneva),
                                   translated, n);
                 thePortp->pnLoc.h = thePortp->pnLoc.h + total;
                 printport.pnLoc.h = thePortp->pnLoc.h;

--- a/src/quickdraw/font.cpp
+++ b/src/quickdraw/font.cpp
@@ -428,7 +428,7 @@ static void buildtable(INTEGER extra)
  *	 right now.  The trouble that the new sizes cause is in the Word 5.1
  *	 ribbon control labels.
  */
-    else if(WIDTHPTR->aFID != geneva && (fondwidthtable = findfondwidths()))
+    else if(WIDTHPTR->aFID != kFontIDGeneva && (fondwidthtable = findfondwidths()))
     {
         howtobuild = FondFract;
         extra = 0;


### PR DESCRIPTION
multiversal moved the legacy font-name aliases (geneva, symbol,
helvetica and friends) behind #if OLDROUTINENAMES in March 2024.
Executor never defines that macro, so as soon as the submodule is
advanced past that commit the aliases vanish from the generated
FontMgr.h and four files stop compiling.

Switch the nine call sites to the kFontID* enumerators

This also advances multiversal to the latest commit, though the submodule
update could be dropped if preferred.